### PR TITLE
Add Excalidraw.com link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Magiscribe Drawing Agent System
 
+Built with [Excalidraw](https://excalidraw.com/) - the open-source virtual whiteboard
+
 ![TypeScript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white)
 ![React](https://img.shields.io/badge/React-58c4dc.svg?style=for-the-badge&logo=react&logoColor=white)
 ![GraphQL](https://img.shields.io/badge/-GraphQL-E10098?style=for-the-badge&logo=graphql&logoColor=white)


### PR DESCRIPTION
This PR adds a link to Excalidraw.com at the top of the README to help users quickly access the original Excalidraw project that this tool is built upon.

Changes:
- Added "Built with [Excalidraw](https://excalidraw.com/) - the open-source virtual whiteboard" right after the project title